### PR TITLE
Fix too high networkx pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 16e0dd4ede915d9650d03905f71c44168299f5556e929c17631da5bfff3a6023
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 
@@ -32,7 +32,7 @@ requirements:
     - urllib3 >=1.26.0
     - wrapt >=1.12.0
   run_constrained:
-    - networkx >=4.3.0
+    - networkx >=2.3.0
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Fixes too high lower pin for ``networkx``.

<!--
Please add any other relevant info below:
-->
Omnipath fix was done here: https://github.com/saezlab/omnipath/commit/849a09b32d83437d2452289cc668b4433772d0a7